### PR TITLE
Fix chinese label garble in face recognition

### DIFF
--- a/face_recognition_gui.py
+++ b/face_recognition_gui.py
@@ -467,7 +467,8 @@ class FaceRecognitionGUI:
                 self.log("🔧 正在初始化识别器...")
                 self.recognizer = YOLOFaceRecognizer(
                     db_path=self.db_path,
-                    confidence=self.confidence_var.get()
+                    confidence=self.confidence_var.get(),
+                    font_path=os.getenv('CHINESE_FONT_PATH')
                 )
             
             # 读取图片
@@ -530,7 +531,8 @@ class FaceRecognitionGUI:
                 self.log("🔧 正在初始化识别器...")
                 self.recognizer = YOLOFaceRecognizer(
                     db_path=self.db_path,
-                    confidence=self.confidence_var.get()
+                    confidence=self.confidence_var.get(),
+                    font_path=os.getenv('CHINESE_FONT_PATH')
                 )
             
             # 设置状态

--- a/recognize_camera.py
+++ b/recognize_camera.py
@@ -9,6 +9,7 @@
 # 导入需要的工具
 import sys  # 系统工具
 import argparse  # 命令行参数解析器
+import os  # 读取环境变量以获取中文字体路径
 from face_recognition_yolo import YOLOFaceRecognizer  # 导入人脸识别器
 
 
@@ -59,6 +60,10 @@ def main():
     # 参数4：检测的信心阈值
     parser.add_argument('--confidence', '-c', type=float, default=0.5,
                        help='检测信心阈值，范围0-1（默认：0.5表示50%把握）')
+
+    # 参数5：中文字体设置
+    parser.add_argument('--font', help='中文字体文件路径（如 NotoSansCJK 或思源黑体）')
+    parser.add_argument('--font-size', type=int, default=20, help='标签文字字号（默认：20）')
     
     # 解析用户输入的参数
     args = parser.parse_args()
@@ -68,10 +73,13 @@ def main():
     print("（第一次运行时可能需要下载AI模型，请耐心等待）")
     
     # 创建识别器对象，传入用户指定的参数
+    # 支持中文字体路径通过环境变量或默认路径自动发现
     recognizer = YOLOFaceRecognizer(
         db_path=args.db,              # 使用哪个人脸数据库
         yolo_model=args.model,        # 使用哪个YOLO模型
-        confidence=args.confidence    # 检测的信心要求
+        confidence=args.confidence,   # 检测的信心要求
+        font_path=(args.font or os.getenv('CHINESE_FONT_PATH')),
+        font_size=args.font_size
     )
     
     # 【第2步】开始摄像头识别

--- a/recognize_image.py
+++ b/recognize_image.py
@@ -9,6 +9,7 @@
 # 导入需要的工具
 import sys  # 系统工具
 import argparse  # 命令行参数解析器
+import os  # 读取环境变量以获取中文字体路径
 from face_recognition_yolo import YOLOFaceRecognizer  # 导入人脸识别器
 
 
@@ -64,6 +65,10 @@ def main():
     # 可选参数5：是否显示结果窗口
     parser.add_argument('--no-show', action='store_true', 
                        help='不显示结果窗口（只保存不显示）')
+
+    # 可选参数6：中文字体路径与字号
+    parser.add_argument('--font', help='中文字体文件路径（如 NotoSansCJK 或思源黑体）')
+    parser.add_argument('--font-size', type=int, default=20, help='标签文字字号（默认：20）')
     
     # 解析用户输入的参数
     args = parser.parse_args()
@@ -73,10 +78,13 @@ def main():
     print("（第一次运行时可能需要下载AI模型，请耐心等待）")
     
     # 创建识别器对象，传入用户指定的参数
+    # 支持中文字体路径通过环境变量或默认路径自动发现
     recognizer = YOLOFaceRecognizer(
         db_path=args.db,              # 使用哪个人脸数据库
         yolo_model=args.model,        # 使用哪个YOLO模型
-        confidence=args.confidence    # 检测的信心要求
+        confidence=args.confidence,   # 检测的信心要求
+        font_path=(args.font or os.getenv('CHINESE_FONT_PATH')),
+        font_size=args.font_size
     )
     
     # 【第2步】处理图片


### PR DESCRIPTION
Switch from OpenCV's `cv2.putText` to Pillow for drawing labels to fix Chinese character garbling.

---
<a href="https://cursor.com/background-agent?bcId=bc-07c67075-3f94-495c-bb06-59d9ee88a187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07c67075-3f94-495c-bb06-59d9ee88a187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

